### PR TITLE
Add support to parse full MarCCD header

### DIFF
--- a/marccd/_io/mccd.py
+++ b/marccd/_io/mccd.py
@@ -1,6 +1,10 @@
+import ctypes
 import os
+import re
 import struct
+
 import numpy as np
+
 
 def read(path_to_image):
     """
@@ -14,31 +18,28 @@ def read(path_to_image):
     Returns
     -------
     (image, metadata, mccdheader) : tuple
-        Returns tuple containing the ndarray of the image, experimental 
+        Returns tuple containing the ndarray of the image, experimental
         metadata and the mccdheader
     """
-    
+
     if not os.path.exists(path_to_image):
         raise ValueError(f"{path_to_image} does not exist")
 
-    with open(path_to_image, 'rb') as mccd:
+    with open(path_to_image, "rb") as mccd:
+        tiffheader = mccd.seek(1024)
+        header_size = ctypes.sizeof(FrameHeader)
+        mccdheader = mccd.read(header_size)
 
-        # Read headers
-        tiffheader = mccd.read(1024)
-        mccdheader = mccd.read(3072)
-
-        # Parse experimental metadata
-        metadata = _parseMCCDHeader(mccdheader)
-        
-        # Read image
+        parsed_header, metadata = _parseMCCDHeader(mccdheader)
         image = np.frombuffer(mccd.read(), dtype=np.uint16)
-        image = image.reshape(metadata["dimensions"])
+        image = image.reshape(parsed_header["nfast"], parsed_header["nslow"])
 
     # Remove dimensions from metadata because it will be determined from
     # the image shape
     metadata.pop("dimensions")
-        
-    return image, metadata, mccdheader
+
+    return image, parsed_header, metadata, mccdheader
+
 
 def write(marccd, outfile):
     """
@@ -52,7 +53,6 @@ def write(marccd, outfile):
         File to which MarCCD image will be written
     """
     with open(outfile, "wb") as out:
-
         # Write TIFF header
         out.write(_getTIFFHeader())
 
@@ -63,14 +63,15 @@ def write(marccd, outfile):
             raise AttributeError("_mccdheader attribute was not found")
 
         # Write image
-        out.write(marccd.image.flatten().reshape(1,-1))
-            
+        out.write(marccd.image.flatten().reshape(1, -1))
+
     return
+
 
 def _parseMCCDHeader(header):
     """
-    Parse experimental metadata from MCCD header. Byte-offsets of 
-    experimental parameters are based on this `reference 
+    Parse experimental metadata from MCCD header. Byte-offsets of
+    experimental parameters are based on this `reference
     <http://www.sb.fsu.edu/~xray/Manuals/marCCD165header.html>`_
 
     Parameters
@@ -78,17 +79,60 @@ def _parseMCCDHeader(header):
     header : bytes
         MCCD header
     """
-    byte2int = struct.Struct("<I")
+    parsed_header = {}
     metadata = {}
-    metadata["dimensions"] = (byte2int.unpack(header[80:84])[0],
-                              byte2int.unpack(header[84:88])[0])
-    metadata["distance"] = float(byte2int.unpack(header[640:644])[0])/1e3
-    metadata["center"] = (float(byte2int.unpack(header[644:648])[0])/1e3,
-                          float(byte2int.unpack(header[648:652])[0])/1e3)
-    metadata["pixelsize"] = (float(byte2int.unpack(header[772:776])[0])/1e3,
-                             float(byte2int.unpack(header[776:780])[0])/1e3)
-    metadata["wavelength"] = float(byte2int.unpack(header[908:912])[0])/1e5
-    return metadata
+
+    for name, fieldtype in FrameHeader._fields_:
+        info = getattr(FrameHeader, name)
+        offset = info.offset
+        size = info.size
+        raw = header[offset : offset + size]
+
+        # Parse based on type
+        if issubclass(fieldtype, ctypes.Array) and issubclass(
+            fieldtype._type_, ctypes.c_char
+        ):
+            # C-style string
+            val = raw.rstrip(b"\x00").decode("ascii", "ignore")
+        elif issubclass(fieldtype, ctypes.Array):
+            # Array of numbers (e.g. c_uint32 * 2)
+            basetype = fieldtype._type_
+            count = fieldtype._length_
+            val = list(ctypes.cast(raw, ctypes.POINTER(basetype * count)).contents)
+        elif issubclass(fieldtype, ctypes.c_uint32):
+            val = int.from_bytes(raw, "little")
+            # print('3')
+        elif issubclass(fieldtype, ctypes.c_int32):
+            val = int.from_bytes(raw, "little", signed=True)
+            # print('4')
+        else:
+            val = raw  # fallback
+            # print('5')
+        parsed_header[name] = val
+
+    metadata["dimensions"] = (
+        parsed_header["nfast"],
+        parsed_header["nslow"],
+    )
+    metadata["distance"] = float(parsed_header["xtal_to_detector"]) / 1e3
+    metadata["center"] = (
+        parsed_header["beam_x"] / 1e3,
+        parsed_header["beam_y"] / 1e3,
+    )
+    metadata["pixelsize"] = (
+        float(parsed_header["pixelsize_x"]) / 1e3,
+        float(parsed_header["pixelsize_y"]) / 1e3,
+    )
+
+    metadata["wavelength"] = float(parsed_header["source_wavelength"]) / 1e5
+
+    pattern = r"(\d{4})(\d{4})(\d{4})\.(\d{2}).(\d{9})"
+    mmdd, hhmm, yyyy, ss, ns = re.match(
+        pattern, parsed_header["acquire_timestamp"]
+    ).groups()
+    metadata["timestamp"] = f"{yyyy}-{mmdd}-{hhmm}-{ss}-{ns}"
+    return parsed_header, metadata
+
 
 def _writeMCCDHeader(marccd):
     """
@@ -100,9 +144,9 @@ def _writeMCCDHeader(marccd):
     marccd : MarCCD
         MarCCD object from which to get experimental metadata
     """
-    # Set up header for indexing 
+    # Set up header for indexing
     header = list(marccd._mccdheader)
-    int2byte = struct.Struct('<I')
+    int2byte = struct.Struct("<I")
 
     # Write image dimensions
     header[80:84] = int2byte.pack(marccd.dimensions[0])
@@ -110,31 +154,32 @@ def _writeMCCDHeader(marccd):
 
     # Write detector distance (two places)
     if marccd.distance is not None:
-        dist = int(marccd.distance*1e3)
+        dist = int(marccd.distance * 1e3)
         header[640:644] = int2byte.pack(dist)
         header[696:700] = int2byte.pack(dist)
 
     # Write beam center
     if marccd.center is not None:
-        centerx = int(marccd.center[0]*1e3)
-        centery = int(marccd.center[1]*1e3)
+        centerx = int(marccd.center[0] * 1e3)
+        centery = int(marccd.center[1] * 1e3)
         header[644:648] = int2byte.pack(centerx)
-        header[648:652] = int2byte.pack(centery)    
-        
+        header[648:652] = int2byte.pack(centery)
+
     # Write pixel size
     if marccd.pixelsize is not None:
-        pixelx = int(marccd.pixelsize[0]*1e3)
-        pixely = int(marccd.pixelsize[1]*1e3)
+        pixelx = int(marccd.pixelsize[0] * 1e3)
+        pixely = int(marccd.pixelsize[1] * 1e3)
         header[772:776] = int2byte.pack(pixelx)
         header[776:780] = int2byte.pack(pixely)
 
     # Write X-ray wavelength
     if marccd.wavelength is not None:
-        wavelength = int(np.round(marccd.wavelength*1e5))
+        wavelength = int(np.round(marccd.wavelength * 1e5))
         header[908:912] = int2byte.pack(wavelength)
-    
+
     return bytes(header)
-    
+
+
 def _getTIFFHeader():
     """
     Get the default 1024 byte TIFF header for MCCD images
@@ -144,19 +189,192 @@ def _getTIFFHeader():
     tiffheader : bytes
         1024 byte TIFF header
     """
-    tiffheader = (b'II*\x00\x08\x00\x00\x00\r\x00\x00\x01\x04\x00\x01'
-                  b'\x00\x00\x00\x00\x0f\x00\x00\x01\x01\x04\x00\x01\x00'
-                  b'\x00\x00\x00\x0f\x00\x00\x02\x01\x03\x00\x01\x00\x00'
-                  b'\x00\x10\x00\x00\x00\x03\x01\x03\x00\x01\x00\x00\x00'
-                  b'\x01\x00\x00\x00\x06\x01\x03\x00\x01\x00\x00\x00\x01'
-                  b'\x00\x00\x00\x11\x01\x04\x00\x01\x00\x00\x00\x00\x10'
-                  b'\x00\x00\x12\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00'
-                  b'\x00\x16\x01\x04\x00\x01\x00\x00\x00\x00\x0f\x00\x00'
-                  b'\x17\x01\x04\x00\x01\x00\x00\x00\x00\x00\xc2\x01\x1a'
-                  b'\x01\x05\x00\x01\x00\x00\x00\xaa\x00\x00\x00\x1b\x01'
-                  b'\x05\x00\x01\x00\x00\x00\xb2\x00\x00\x00(\x01\x03\x00'
-                  b'\x01\x00\x00\x00\x03\x00\x00\x00\x96\x87\x04\x00\x01'
-                  b'\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x80\x96'
-                  b'\x98\x00\x18Z\x01\x00\x80\x96\x98\x00\x18Z\x01')
-    tiffheader += b'\x00'*839
+    tiffheader = (
+        b"II*\x00\x08\x00\x00\x00\r\x00\x00\x01\x04\x00\x01"
+        b"\x00\x00\x00\x00\x0f\x00\x00\x01\x01\x04\x00\x01\x00"
+        b"\x00\x00\x00\x0f\x00\x00\x02\x01\x03\x00\x01\x00\x00"
+        b"\x00\x10\x00\x00\x00\x03\x01\x03\x00\x01\x00\x00\x00"
+        b"\x01\x00\x00\x00\x06\x01\x03\x00\x01\x00\x00\x00\x01"
+        b"\x00\x00\x00\x11\x01\x04\x00\x01\x00\x00\x00\x00\x10"
+        b"\x00\x00\x12\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00"
+        b"\x00\x16\x01\x04\x00\x01\x00\x00\x00\x00\x0f\x00\x00"
+        b"\x17\x01\x04\x00\x01\x00\x00\x00\x00\x00\xc2\x01\x1a"
+        b"\x01\x05\x00\x01\x00\x00\x00\xaa\x00\x00\x00\x1b\x01"
+        b"\x05\x00\x01\x00\x00\x00\xb2\x00\x00\x00(\x01\x03\x00"
+        b"\x01\x00\x00\x00\x03\x00\x00\x00\x96\x87\x04\x00\x01"
+        b"\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x80\x96"
+        b"\x98\x00\x18Z\x01\x00\x80\x96\x98\x00\x18Z\x01"
+    )
+    tiffheader += b"\x00" * 839
     return tiffheader
+
+
+class FrameHeader(ctypes.LittleEndianStructure):
+    """
+    Python representation of a MarCCD header.
+
+    This class maps to the binary layout of a MarCCD image header,
+    starting at byte 1024 in the file. MarCCD uses little-endian
+    byte order and packed layout (set with `_pack_=1`). Byte-offsets
+    are based on this `reference<https://marxperts.com/man/pdf/marccd_manual.v2.pdf>`
+    """
+
+    _pack_ = 1
+    _fields_ = [
+        # --- File/header format parameters (256 bytes) ---
+        ("header_type", ctypes.c_uint32),
+        ("header_name", ctypes.c_char * 16),
+        ("header_major_version", ctypes.c_uint32),
+        ("header_minor_version", ctypes.c_uint32),
+        ("header_byte_order", ctypes.c_uint32),
+        ("data_byte_order", ctypes.c_uint32),
+        ("header_size", ctypes.c_uint32),
+        ("frame_type", ctypes.c_uint32),
+        ("magic_number", ctypes.c_int32),
+        ("compression_type", ctypes.c_uint32),
+        ("compression1", ctypes.c_uint32),
+        ("compression2", ctypes.c_uint32),
+        ("compression3", ctypes.c_uint32),
+        ("compression4", ctypes.c_uint32),
+        ("compression5", ctypes.c_uint32),
+        ("compression6", ctypes.c_uint32),
+        ("nheaders", ctypes.c_uint32),
+        ("nfast", ctypes.c_uint32),
+        ("nslow", ctypes.c_uint32),
+        ("depth", ctypes.c_uint32),
+        ("record_length", ctypes.c_uint32),
+        ("signif_bits", ctypes.c_uint32),
+        ("data_type", ctypes.c_uint32),
+        ("saturated_value", ctypes.c_uint32),
+        ("sequence", ctypes.c_uint32),
+        ("nimages", ctypes.c_uint32),
+        ("origin", ctypes.c_uint32),
+        ("orientation", ctypes.c_uint32),
+        ("view_direction", ctypes.c_uint32),
+        ("overflow_location", ctypes.c_uint32),
+        ("over_8_bits", ctypes.c_uint32),
+        ("over_16_bits", ctypes.c_uint32),
+        ("multiplexed", ctypes.c_uint32),
+        ("nfastimages", ctypes.c_uint32),
+        ("nslowimages", ctypes.c_uint32),
+        ("darkcurrent_applied", ctypes.c_uint32),
+        ("bias_applied", ctypes.c_uint32),
+        ("flatfield_applied", ctypes.c_uint32),
+        ("distortion_applied", ctypes.c_uint32),
+        ("original_header_type", ctypes.c_uint32),
+        ("file_saved", ctypes.c_uint32),
+        ("n_valid_pixels", ctypes.c_uint32),
+        ("defectmap_applied", ctypes.c_uint32),
+        ("subimage_nfast", ctypes.c_uint32),
+        ("subimage_nslow", ctypes.c_uint32),
+        ("subimage_origin_fast", ctypes.c_uint32),
+        ("subimage_origin_slow", ctypes.c_uint32),
+        ("readout_pattern", ctypes.c_uint32),
+        ("saturation_level", ctypes.c_uint32),
+        ("orientation_code", ctypes.c_uint32),
+        ("frameshift_multiplexed", ctypes.c_uint32),
+        ("prescan_nfast", ctypes.c_uint32),
+        ("prescan_nslow", ctypes.c_uint32),
+        ("postscan_nfast", ctypes.c_uint32),
+        ("postscan_nslow", ctypes.c_uint32),
+        ("prepost_trimmed", ctypes.c_uint32),
+        ("reserve1", ctypes.c_char * ((64 - 55) * 4 - 16)),
+        # --- Data statistics (128 bytes) ---
+        ("total_counts", ctypes.c_uint32 * 2),
+        ("special_counts1", ctypes.c_uint32 * 2),
+        ("special_counts2", ctypes.c_uint32 * 2),
+        ("min", ctypes.c_uint32),
+        ("max", ctypes.c_uint32),
+        ("mean", ctypes.c_int32),
+        ("rms", ctypes.c_uint32),
+        ("n_zeros", ctypes.c_uint32),
+        ("n_saturated", ctypes.c_uint32),
+        ("stats_uptodate", ctypes.c_uint32),
+        ("pixel_noise", ctypes.c_uint32 * 9),
+        ("reserve2", ctypes.c_char * ((32 - 13 - 9) * 4)),
+        # --- Sample Changer info (256 bytes) ---
+        ("barcode", ctypes.c_char * 16),
+        ("barcode_angle", ctypes.c_uint32),
+        ("barcode_status", ctypes.c_uint32),
+        ("reserve2a", ctypes.c_char * ((64 - 6) * 4)),
+        # --- Goniostat parameters (128 bytes) ---
+        ("xtal_to_detector", ctypes.c_int32),
+        ("beam_x", ctypes.c_int32),
+        ("beam_y", ctypes.c_int32),
+        ("integration_time", ctypes.c_int32),
+        ("exposure_time", ctypes.c_int32),
+        ("readout_time", ctypes.c_int32),
+        ("nreads", ctypes.c_int32),
+        ("start_twotheta", ctypes.c_int32),
+        ("start_omega", ctypes.c_int32),
+        ("start_chi", ctypes.c_int32),
+        ("start_kappa", ctypes.c_int32),
+        ("start_phi", ctypes.c_int32),
+        ("start_delta", ctypes.c_int32),
+        ("start_gamma", ctypes.c_int32),
+        ("start_xtal_to_detector", ctypes.c_int32),
+        ("end_twotheta", ctypes.c_int32),
+        ("end_omega", ctypes.c_int32),
+        ("end_chi", ctypes.c_int32),
+        ("end_kappa", ctypes.c_int32),
+        ("end_phi", ctypes.c_int32),
+        ("end_delta", ctypes.c_int32),
+        ("end_gamma", ctypes.c_int32),
+        ("end_xtal_to_detector", ctypes.c_int32),
+        ("rotation_axis", ctypes.c_int32),
+        ("rotation_range", ctypes.c_int32),
+        ("detector_rotx", ctypes.c_int32),
+        ("detector_roty", ctypes.c_int32),
+        ("detector_rotz", ctypes.c_int32),
+        ("total_dose", ctypes.c_int32),
+        ("reserve3", ctypes.c_char * ((32 - 29) * 4)),
+        # --- Detector parameters (128 bytes) ---
+        ("detector_type", ctypes.c_int32),
+        ("pixelsize_x", ctypes.c_int32),
+        ("pixelsize_y", ctypes.c_int32),
+        ("mean_bias", ctypes.c_int32),
+        ("photons_per_100adu", ctypes.c_int32),
+        ("measured_bias", ctypes.c_int32 * 9),
+        ("measured_temperature", ctypes.c_int32 * 9),
+        ("measured_pressure", ctypes.c_int32 * 9),
+        # --- X-ray source parameters (64 bytes) ---
+        ("source_type", ctypes.c_int32),
+        ("source_dx", ctypes.c_int32),
+        ("source_dy", ctypes.c_int32),
+        ("source_wavelength", ctypes.c_int32),
+        ("source_power", ctypes.c_int32),
+        ("source_voltage", ctypes.c_int32),
+        ("source_current", ctypes.c_int32),
+        ("source_bias", ctypes.c_int32),
+        ("source_polarization_x", ctypes.c_int32),
+        ("source_polarization_y", ctypes.c_int32),
+        ("source_intensity_0", ctypes.c_int32),
+        ("source_intensity_1", ctypes.c_int32),
+        ("reserve_source", ctypes.c_char * (2 * 4)),
+        # --- X-ray optics parameters (128 bytes) ---
+        ("optics_type", ctypes.c_int32),
+        ("optics_dx", ctypes.c_int32),
+        ("optics_dy", ctypes.c_int32),
+        ("optics_wavelength", ctypes.c_int32),
+        ("optics_dispersion", ctypes.c_int32),
+        ("optics_crossfire_x", ctypes.c_int32),
+        ("optics_crossfire_y", ctypes.c_int32),
+        ("optics_angle", ctypes.c_int32),
+        ("optics_polarization_x", ctypes.c_int32),
+        ("optics_polarization_y", ctypes.c_int32),
+        ("reserve_optics", ctypes.c_char * (4 * 4)),
+        ("reserve5", ctypes.c_char * ((32 - 28) * 4)),
+        # --- File parameters (1024 bytes) ---
+        ("filetitle", ctypes.c_char * 128),
+        ("filepath", ctypes.c_char * 128),
+        ("filename", ctypes.c_char * 64),
+        ("acquire_timestamp", ctypes.c_char * 32),
+        ("header_timestamp", ctypes.c_char * 32),
+        ("save_timestamp", ctypes.c_char * 32),
+        ("file_comment", ctypes.c_char * 512),
+        ("reserve6", ctypes.c_char * (1024 - (128 + 128 + 64 + (3 * 32) + 512))),
+        # --- Dataset parameters (512 bytes) ---
+        ("dataset_comment", ctypes.c_char * 512),
+        # --- User-definable data (512 bytes) ---
+        ("user_data", ctypes.c_char * 512),
+    ]

--- a/marccd/marccd.py
+++ b/marccd/marccd.py
@@ -230,7 +230,7 @@ class MarCCD:
     @property
     def timestamp(self):
         """
-        Pixel size in microns
+        Timestamp of image acquisition
 
         Returns
         -------
@@ -242,7 +242,7 @@ class MarCCD:
 
     @timestamp.setter
     def timestamp(self, value):
-        """Sets the pixel size to provided value"""
+        """Sets the timestamp to the provided value"""
         self.__timestamp = value
 
     @property

--- a/tests/test_marccd.py
+++ b/tests/test_marccd.py
@@ -1,16 +1,17 @@
-import marccd
 import unittest
+from os.path import abspath, basename, dirname, join
+
 import numpy as np
-from os.path import join, abspath, dirname, basename
+
+import marccd
+
 
 class TestMarCCD(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
-        cls.testImage = join(abspath(dirname(__file__)),
-                             "data", "e074a_off1_011.mccd")
+        cls.testImage = join(abspath(dirname(__file__)), "data", "e074a_off1_011.mccd")
         return
-    
+
     def test_init_empty(self):
         """Unit tests for MarCCD default empty constructor"""
 
@@ -21,31 +22,37 @@ class TestMarCCD(unittest.TestCase):
         self.assertIsNone(mccd.distance)
         self.assertIsNone(mccd.center)
         self.assertIsNone(mccd.pixelsize)
+        self.assertIsNone(mccd.timestamp)
         self.assertIsNone(mccd.wavelength)
-        self.assertEqual(b'\x00'*3072, mccd._mccdheader)
-        
+        self.assertIsNone(mccd._parsedheader)
+        self.assertEqual(b"\x00" * 3072, mccd._mccdheader)
+
         # Empty image, provide attributes
-        mccd = marccd.MarCCD(name="name",
-                             distance=200.0,
-                             center=(1985.3, 1975.4),
-                             pixelsize=(88.6, 88.6),
-                             wavelength=1.0255)
+        mccd = marccd.MarCCD(
+            name="name",
+            distance=200.0,
+            center=(1985.3, 1975.4),
+            pixelsize=(88.6, 88.6),
+            timestamp="2019-1110-1553-20-765444000",
+            wavelength=1.0255,
+        )
         self.assertTrue(np.array_equal(np.empty((0, 0)), mccd.image))
         self.assertEqual("name", mccd.name)
         self.assertEqual(200.0, mccd.distance)
         self.assertEqual((1985.3, 1975.4), mccd.center)
         self.assertEqual((88.6, 88.6), mccd.pixelsize)
+        self.assertEqual("2019-1110-1553-20-765444000", mccd.timestamp)
         self.assertEqual(1.0255, mccd.wavelength)
-        self.assertEqual(b'\x00'*3072, mccd._mccdheader)
+        self.assertEqual(b"\x00" * 3072, mccd._mccdheader)
 
         # Invalid data argument
         with self.assertRaises(ValueError):
             marccd.MarCCD(10)
-        with self.assertRaises(ValueError):            
+        with self.assertRaises(ValueError):
             marccd.MarCCD(data=10)
-        
+
         return
-    
+
     def test_init_image(self):
         """Unit tests for initializing MarCCD from image"""
 
@@ -56,35 +63,39 @@ class TestMarCCD(unittest.TestCase):
         self.assertEqual(199.995, mccd.distance)
         self.assertEqual((1989.0, 1974.0), mccd.center)
         self.assertEqual((88.6, 88.6), mccd.pixelsize)
+        self.assertEqual("2019-1110-1553-20-765444000", mccd.timestamp)
         self.assertEqual(1.0264, mccd.wavelength)
-        self.assertNotEqual(b'\x00'*3072, mccd._mccdheader)
+        self.assertNotEqual(b"\x00" * 3072, mccd._mccdheader)
 
         # Initialize from image, provide attributes to ensure they are
         # prioritized over MCCD header
-        mccd = marccd.MarCCD(self.testImage,
-                             name="name",
-                             distance=200.0,
-                             center=(1985.3, 1975.4),
-                             pixelsize=(88.0, 88.0),
-                             wavelength=1.0255)
+        mccd = marccd.MarCCD(
+            self.testImage,
+            name="name",
+            distance=200.0,
+            center=(1985.3, 1975.4),
+            pixelsize=(88.0, 88.0),
+            timestamp="2019-1110-1553-21-765444000",
+            wavelength=1.0255,
+        )
         self.assertFalse(np.array_equal(np.empty((0, 0)), mccd.image))
         self.assertEqual("name", mccd.name)
         self.assertEqual(200.0, mccd.distance)
         self.assertEqual((1985.3, 1975.4), mccd.center)
         self.assertEqual((88.0, 88.0), mccd.pixelsize)
+        self.assertEqual("2019-1110-1553-21-765444000", mccd.timestamp)
         self.assertEqual(1.0255, mccd.wavelength)
-        self.assertNotEqual(b'\x00'*3072, mccd._mccdheader)
-        
+        self.assertNotEqual(b"\x00" * 3072, mccd._mccdheader)
+
         return
 
     def test_init_ndarray(self):
         """Unit tests for initializing MarCCD from ndarray"""
 
-        randimage = np.random.randint(low=0,
-                                      high=(2**16)-1,
-                                      size=(500, 500),
-                                      dtype=np.uint16)
-        
+        randimage = np.random.randint(
+            low=0, high=(2**16) - 1, size=(500, 500), dtype=np.uint16
+        )
+
         # ndarray image, no attributes provided
         mccd = marccd.MarCCD(randimage)
         self.assertEqual((500, 500), mccd.image.shape)
@@ -92,29 +103,34 @@ class TestMarCCD(unittest.TestCase):
         self.assertIsNone(mccd.distance)
         self.assertIsNone(mccd.center)
         self.assertIsNone(mccd.pixelsize)
+        self.assertIsNone(mccd.timestamp)
         self.assertIsNone(mccd.wavelength)
-        self.assertEqual(b'\x00'*3072, mccd._mccdheader)
-        
+        self.assertEqual(b"\x00" * 3072, mccd._mccdheader)
+
         # ndarray image, provide attributes
-        mccd = marccd.MarCCD(randimage,
-                             name="name",
-                             distance=200.0,
-                             center=(1985.3, 1975.4),
-                             pixelsize=(88.6, 88.6),
-                             wavelength=1.0255)
+        mccd = marccd.MarCCD(
+            randimage,
+            name="name",
+            distance=200.0,
+            center=(1985.3, 1975.4),
+            pixelsize=(88.6, 88.6),
+            timestamp="2019-1110-1553-21-765444000",
+            wavelength=1.0255,
+        )
         self.assertEqual((500, 500), mccd.image.shape)
         self.assertEqual("name", mccd.name)
         self.assertEqual(200.0, mccd.distance)
         self.assertEqual((1985.3, 1975.4), mccd.center)
         self.assertEqual((88.6, 88.6), mccd.pixelsize)
+        self.assertEqual("2019-1110-1553-21-765444000", mccd.timestamp)
         self.assertEqual(1.0255, mccd.wavelength)
-        self.assertEqual(b'\x00'*3072, mccd._mccdheader)
+        self.assertEqual(b"\x00" * 3072, mccd._mccdheader)
 
         # providing dtype other than np.uint16 should generate warning
         randimage = np.random.randint(0, 100, (500, 500), np.int16)
         with self.assertWarns(UserWarning):
             mccd = marccd.MarCCD(randimage)
-        
+
         return
 
     def test_dimensions(self):
@@ -136,13 +152,14 @@ class TestMarCCD(unittest.TestCase):
         mccd = marccd.MarCCD(randimage)
         dims = mccd.dimensions
         self.assertTrue(f"<marccd.MarCCD with {dims[0]}x{dims[1]} pixels" in str(mccd))
-        
+
         return
-        
+
     def test_readwrite(self):
         """Unit test for MarCCD reading and writing"""
-        import filecmp, os
-        
+        import filecmp
+        import os
+
         # Test round trip leaves MCCD image unchanged
         mccd = marccd.MarCCD(self.testImage)
         datadir = dirname(self.testImage)
@@ -152,5 +169,3 @@ class TestMarCCD(unittest.TestCase):
         os.remove(temp)
 
         return
-        
-        


### PR DESCRIPTION
This PR adds a new `FrameHeader` class using `ctypes.LittleEndianStructure` to parse the entire MarCCD frame header starting at byte 1024, and maps directly to the metadata outlined in https://marxperts.com/man/pdf/marccd_manual.v2.pdf. 

The parsed header is stored as a Python dictionary and stored in the `MarCCD._parsedheader` attribute. I also added a `MarCCD.timestamp` attribute, formatted as `YYYY-MMDD-HHmm-ss-nanoseconds`. 

I also added additional checks to the test script, and confirmed they pass. 

Side note: my formatter automatically cleaned up some whitespace. I'm happy to revert theses changes if needed.
